### PR TITLE
docs: Update READMEs for project overview and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,99 @@
+# Project Title: Sentiment Analysis Platform (Monorepo)
 
+This project is a monorepo containing a suite of applications and services for sentiment analysis. It includes a web interface, a backend API, a sentiment analysis processing service, and shared libraries.
 
+## Project Overview
 
+This monorepo is managed using `pnpm` and `Turborepo`. It consists of the following main components:
 
-## PytonSentiment Analysis
-- uvicorn main:app --reload
+*   **`apps/web`**: A [Next.js](https://nextjs.org/) frontend application that provides the user interface for interacting with the platform.
+*   **`apps/server`**: A [NestJS](https://nestjs.com/) backend application that serves as the main API for the platform.
+*   **`apps/sentiment-analysis-service`**: A Python (FastAPI/Uvicorn) service responsible for performing sentiment analysis on given texts.
+*   **`packages/database`**: A shared package managing database schemas (using [Prisma](https://www.prisma.io/)) and providing a database client.
+*   **`packages/services`**: A shared library containing common business logic and services utilized by other applications in the monorepo.
+
+## Getting Started
+
+### Prerequisites
+
+*   **Node.js**: Version 18 or higher (as specified in `package.json`). You can use [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions.
+*   **pnpm**: Version 9.0.0 or higher (as specified in `package.json`). Install via `npm install -g pnpm`.
+*   **Docker**: Required for running the PostgreSQL database. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or Docker Engine.
+
+### Installation
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+2.  **Install dependencies:**
+    Install all dependencies for all packages and applications using `pnpm` at the root of the monorepo:
+    ```bash
+    pnpm install
+    ```
+3.  **Set up environment variables:**
+    Each application (`apps/web`, `apps/server`, `apps/sentiment-analysis-service`) might require its own `.env` file for configuration (e.g., database connection strings, API keys). Refer to the README within each application's directory for specific environment variables needed.
+    *   For the `apps/server` to connect to the PostgreSQL database, you'll typically need a `.env` file in `apps/server/` with at least:
+        ```env
+        DATABASE_URL="postgresql://postgres:postgres@localhost:5432/sentiment-hound?schema=public"
+        ```
+
+## Running the Application
+
+1.  **Start the Database:**
+    The project uses a PostgreSQL database run via Docker. Start the database service using Docker Compose:
+    ```bash
+    docker-compose up -d
+    ```
+    This will start a PostgreSQL server on port `5432` with the database named `sentiment-hound` and credentials `postgres/postgres`.
+
+2.  **Run Development Servers:**
+    Once the database is running, you can start all the applications (frontend, backend, and sentiment analysis service if configured) in development mode using Turborepo:
+    ```bash
+    pnpm run dev
+    ```
+    This command, defined in the root `package.json`, will typically:
+    *   Run database migrations/generations (as per `turbo.json` dependencies like `db:generate`).
+    *   Start the Next.js frontend (usually on `http://localhost:3000`).
+    *   Start the NestJS backend server (usually on `http://localhost:3001` or similar, check its configuration).
+    *   Start the Python sentiment analysis service (port needs to be configured, e.g., `8000`).
+
+    Refer to the individual README files in `apps/web`, `apps/server`, and `apps/sentiment-analysis-service` for specific port numbers and to confirm they are part of the `turbo dev` pipeline.
+
+## Development
+
+### Common Scripts
+
+The following scripts are available at the root of the monorepo:
+
+*   **`pnpm run dev`**: Starts all applications in development mode.
+*   **`pnpm run build`**: Builds all applications and packages for production.
+*   **`pnpm run lint`**: Lints the codebase across all packages.
+*   **`pnpm run format`**: Formats the code using Prettier.
+
+### Database Management
+
+The `turbo.json` file defines several scripts for database management, which are typically run via `pnpm turbo db:<command>`. Examples:
+*   `pnpm turbo db:generate`: Generates Prisma client based on schema changes.
+*   `pnpm turbo db:migrate`: Runs database migrations.
+*   `pnpm turbo db:seed`: Seeds the database with initial data.
+
+Refer to `turbo.json` and `packages/database/package.json` (if it exists and has scripts) for more details on database-related commands.
+
+## Shared Packages
+
+*   **`packages/database`**:
+    *   Manages the database schema using Prisma.
+    *   Provides a Prisma client for database interactions.
+    *   Contains seed scripts for populating the database.
+*   **`packages/services`**:
+    *   A collection of shared services and business logic used across different parts of the application (e.g., by `apps/server`).
+
+## Individual Application/Service Details
+
+For more detailed information on each specific application or service, including its specific setup, environment variables, and how to run it independently, please refer to its respective README file:
+
+*   [apps/web/README.md](./apps/web/README.md)
+*   [apps/server/README.md](./apps/server/README.md)
+*   [apps/sentiment-analysis-service/README.md](./apps/sentiment-analysis-service/README.md)

--- a/apps/sentiment-analysis-service/README.md
+++ b/apps/sentiment-analysis-service/README.md
@@ -1,0 +1,73 @@
+# Sentiment Analysis Service
+
+This service is a Python application built with [FastAPI](https://fastapi.tiangolo.com/) and [Uvicorn](https://www.uvicorn.org/) to provide sentiment analysis capabilities. It utilizes transformer models for text analysis.
+
+## Functionality
+
+The service exposes API endpoints to analyze the sentiment of a given text. (Further details about specific endpoints should be added here if known, e.g., `/sentiment`, expected request/response formats).
+
+## Setup and Installation
+
+### Prerequisites
+
+*   Python (e.g., 3.9+). It's recommended to use a virtual environment.
+*   `pip` for installing dependencies.
+
+### Dependencies
+
+The service requires the following Python packages:
+
+*   fastapi
+*   uvicorn
+*   transformers
+*   torch
+*   pyabsa
+
+### Installation
+
+1.  **Navigate to the service directory:**
+    ```bash
+    cd apps/sentiment-analysis-service
+    ```
+
+2.  **(Optional but Recommended) Create and activate a virtual environment:**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Running the Service
+
+To run the sentiment analysis service locally:
+
+1.  Ensure you are in the `apps/sentiment-analysis-service` directory.
+2.  If using a virtual environment, make sure it's activated.
+3.  Start the Uvicorn server:
+    ```bash
+    uvicorn main:app --reload --host 0.0.0.0 --port 8000
+    ```
+    *   `main:app`: Assumes your FastAPI application instance is named `app` in a file named `main.py`.
+    *   `--reload`: Enables auto-reloading when code changes (for development).
+    *   `--host 0.0.0.0`: Makes the server accessible from outside the container/machine if needed.
+    *   `--port 8000`: Runs the service on port 8000. You can change this if needed.
+
+The API should then be accessible at `http://localhost:8000`.
+
+## Environment Variables
+
+If the service requires any environment variables (e.g., for model paths, configurations), list them here with descriptions. For example:
+*   `MODEL_PATH`: Path to the pre-trained sentiment analysis model.
+*   `API_KEY_OTHER_SERVICE`: If it needs to communicate with other services.
+
+(Currently, no specific environment variables are known; this section is a placeholder).
+
+## Integration with Monorepo (Turborepo)
+
+It's also possible this service is intended to be run via the root `pnpm run dev` command. If so, there should be a `dev` script in this service's `package.json` (if one exists for Python projects in this monorepo structure) or configuration in the root `turbo.json` that handles starting this service.
+
+If this service *is not* automatically started by `pnpm run dev` from the root, you will need to run it manually using the `uvicorn` command above in a separate terminal.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -5,13 +5,13 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 First, run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+# Using pnpm (recommended for this monorepo)
 pnpm dev
-# or
-bun dev
+
+# Other package managers (if you are managing this app independently)
+# npm run dev
+# yarn dev
+# bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION
This commit significantly revises the project's README files:

1.  **Root README.md:**
    *   Added a comprehensive project overview, detailing the monorepo structure (Next.js frontend, NestJS backend, Python sentiment analysis service, shared database and services packages).
    *   Included detailed "Getting Started" instructions: prerequisites (Node.js, pnpm, Docker), global installation (`pnpm install`), and environment variable setup guidance.
    *   Added a "Running the Application" section, explaining how to start the Dockerized PostgreSQL database (`docker-compose up -d`) and run all applications via Turborepo (`pnpm run dev`).
    *   Added a "Development" section outlining common scripts (`pnpm run dev`, `build`, `lint`, `format`) and database management via Turborepo tasks.
    *   Briefly described shared packages (`packages/database`, `packages/services`).
    *   Linked to individual application READMEs for more specific details.

2.  **apps/sentiment-analysis-service/README.md:**
    *   Created a new README for the Python FastAPI service.
    *   Described its functionality, setup (Python, venv, `pip install -r requirements.txt`), and how to run it using `uvicorn main:app --reload`.
    *   Listed dependencies from `requirements.txt`.
    *   Added placeholders for environment variables and notes on monorepo integration.

3.  **apps/web/README.md:**
    *   Standardized the "Getting Started" section to recommend `pnpm dev` for running the Next.js development server, aligning with the monorepo's primary package manager.

These changes provide clear and comprehensive documentation for developers to understand, set up, run, and develop the project.