### PR TITLE
Upgrade Mantine to v8.0.2 and fix related build issues

### DIFF
--- a/apps/web/app/dashboard/comments/components/CommentDrawer.tsx
+++ b/apps/web/app/dashboard/comments/components/CommentDrawer.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 
 interface ISelectedComment {
   content: string;
-  sentiment: string;
+  sentiment: string | null;
   provider: string;
   // aspects: Array<{ aspect: string; sentiment: string }>; // Assuming structure for aspects
 }

--- a/apps/web/app/dashboard/comments/page.tsx
+++ b/apps/web/app/dashboard/comments/page.tsx
@@ -28,6 +28,14 @@ const CommentsPage = async ({
     ? await mentionService.getMention(parseInt(String(commentId)))
     : null;
 
+  // Augment selectedComment with the provider property if it exists
+  const augmentedSelectedComment = selectedComment
+    ? {
+        ...selectedComment,
+        provider: selectedComment.sourceType || "Unknown", // Use sourceType or a default
+      }
+    : null;
+
   if (!session?.user?.id) {
     return (
       <Box p="xl" ta="center">
@@ -72,8 +80,8 @@ const CommentsPage = async ({
           }}
         />
         <CommentDrawer
-          opened={!!selectedComment}
-          selectedComment={selectedComment}
+          opened={!!augmentedSelectedComment}
+          selectedComment={augmentedSelectedComment}
         />
       </Box>
     );

--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/next-auth.lib";
 import PageLayout from "@/components/templates/PageLayout";
-import { Card, Flex, Box, Title, Stack } from "@mantine/core";
+import { Card, Flex, Box, Title, Stack, Text } from "@mantine/core";
 import ProfileCard from "./components/ProfileCard";
 import Plans from "./components/Plans";
 import { prisma } from "@repo/db";
@@ -26,7 +26,11 @@ const ProfilePage = async () => {
               <Title ml={4} mb={4} order={3}>
                 Plan
               </Title>
-              <ProfileCard user={user} id={String(userId)} />
+              {user ? (
+                <ProfileCard user={user} />
+              ) : (
+                <Text>User data not available.</Text>
+              )}
             </Card>
           </Flex>
           <Flex w="33%">
@@ -36,10 +40,12 @@ const ProfilePage = async () => {
           </Flex>
         </Flex>
       </Stack>
-      <Box mt={24}>
-        <Title order={3}>Subscription Details</Title>
-        <Plans userPlanId={String(user?.planId)} />
-      </Box>
+      {user ? (
+        <Box mt={24}>
+          <Title order={3}>Subscription Details</Title>
+          <Plans userPlanId={String(user.planId)} />
+        </Box>
+      ) : null}
     </PageLayout>
   );
 };

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
     experimental: {
         optimizePackageImports: ['@mantine/core', '@mantine/hooks'],
     },
+    transpilePackages: ['@repo/db', '@repo/services'],
     images: {
         domains: ['lh3.googleusercontent.com']
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,11 +12,11 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
-    "@mantine/charts": "^7.17.3",
-    "@mantine/core": "^7.16.3",
-    "@mantine/form": "^7.17.3",
-    "@mantine/hooks": "^7.16.3",
-    "@mantine/notifications": "^7.16.3",
+    "@mantine/charts": "8.0.2",
+    "@mantine/core": "8.0.2",
+    "@mantine/form": "8.0.2",
+    "@mantine/hooks": "8.0.2",
+    "@mantine/notifications": "8.0.2",
     "@repo/db": "workspace:*",
     "@repo/services": "workspace:*",
     "@tabler/icons-react": "^3.30.0",
@@ -35,7 +35,7 @@
     "@types/react-dom": "19.0.3",
     "eslint": "^9.20.0",
     "postcss": "^8.5.2",
-    "postcss-preset-mantine": "^1.17.0",
+    "postcss-preset-mantine": "1.17.0",
     "postcss-simple-vars": "^7.0.1",
     "typescript": "5.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "turbo": "^2.4.2",
     "typescript": "5.7.3"
   },
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.11.1",
   "engines": {
     "node": ">=18"
   }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -9,7 +9,7 @@
     }
   },
   "scripts": {
-    "db:build": "tsc -p tsconfig.build.json",
+    "build": "prisma generate && tsc -p tsconfig.build.json",
     "db:push": "prisma db push --accept-data-loss",
     "db:format": "prisma format",
     "db:generate": "prisma generate",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -9,7 +9,7 @@
     }
   },
   "scripts": {
-    "services:build": "tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "services:watch": "tsc --project tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
       '@nestjs/schedule':
         specifier: ^5.0.1
-        version: 5.0.1(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1))
+        version: 5.0.1(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
       '@repo/db':
         specifier: workspace:*
         version: link:../../packages/database
@@ -59,7 +59,7 @@ importers:
         version: 10.0.0(chokidar@3.5.3)(typescript@5.1.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0))
+        version: 10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.17
@@ -121,20 +121,20 @@ importers:
         specifier: ^2.7.4
         version: 2.7.4(@prisma/client@6.3.1(prisma@6.3.1(typescript@5.7.3))(typescript@5.7.3))
       '@mantine/charts':
-        specifier: ^7.17.3
-        version: 7.17.3(@mantine/core@7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@7.16.3(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(recharts@2.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 8.0.2
+        version: 8.0.2(@mantine/core@8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@8.0.2(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(recharts@2.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@mantine/core':
-        specifier: ^7.16.3
-        version: 7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 8.0.2
+        version: 8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mantine/form':
-        specifier: ^7.17.3
-        version: 7.17.3(react@19.0.0)
+        specifier: 8.0.2
+        version: 8.0.2(react@19.0.0)
       '@mantine/hooks':
-        specifier: ^7.16.3
-        version: 7.16.3(react@19.0.0)
+        specifier: 8.0.2
+        version: 8.0.2(react@19.0.0)
       '@mantine/notifications':
-        specifier: ^7.16.3
-        version: 7.16.3(@mantine/core@7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@7.16.3(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 8.0.2
+        version: 8.0.2(@mantine/core@8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@8.0.2(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@repo/db':
         specifier: workspace:*
         version: link:../../packages/database
@@ -185,7 +185,7 @@ importers:
         specifier: ^8.5.2
         version: 8.5.2
       postcss-preset-mantine:
-        specifier: ^1.17.0
+        specifier: 1.17.0
         version: 1.17.0(postcss@8.5.2)
       postcss-simple-vars:
         specifier: ^7.0.1
@@ -810,42 +810,42 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
-  '@mantine/charts@7.17.3':
-    resolution: {integrity: sha512-YGx8hLi4E3yyiRx9fNAoPPF+YrFkLWM+fnzqKIVvRbWqMbUw920AU+K5XSDjPmNB7cuYWSVwxxA/hIstQ8x3VA==}
+  '@mantine/charts@8.0.2':
+    resolution: {integrity: sha512-hVS1+CT+7e3+ZbU1xx7Nyx/5ZBSxzS+68SKeVLeOZPGl9Wx35CY1oLn0n53vQPWV2WFKd0u0Bq3d1iuaDpkzGA==}
     peerDependencies:
-      '@mantine/core': 7.17.3
-      '@mantine/hooks': 7.17.3
+      '@mantine/core': 8.0.2
+      '@mantine/hooks': 8.0.2
       react: ^18.x || ^19.x
       react-dom: ^18.x || ^19.x
       recharts: ^2.13.3
 
-  '@mantine/core@7.16.3':
-    resolution: {integrity: sha512-cxhIpfd2i0Zmk9TKdejYAoIvWouMGhzK3OOX+VRViZ5HEjnTQCGl2h3db56ThqB6NfVPCno6BPbt5lwekTtmuQ==}
+  '@mantine/core@8.0.2':
+    resolution: {integrity: sha512-2Ps7bRTeTbRwAKTCL9xdflPz0pwOlTq6ohyTbDZMCADqecf09GHI7GiX+HJatqbPZ2t8jK0fN1b48YhjJaxTqg==}
     peerDependencies:
-      '@mantine/hooks': 7.16.3
+      '@mantine/hooks': 8.0.2
       react: ^18.x || ^19.x
       react-dom: ^18.x || ^19.x
 
-  '@mantine/form@7.17.3':
-    resolution: {integrity: sha512-ktERldD8f9lrjjz6wIbwMnNbAZq8XEWPx4K5WuFyjXaK0PI8D+gsXIGKMtA5rVrAUFHCWCdbK3yLgtjJNki8ew==}
+  '@mantine/form@8.0.2':
+    resolution: {integrity: sha512-vSp9BfrhC9o7RMRYMaND2UAflXO4i6c5F1qPkiM2FID6ye2RJxW8YHaGa3kA0VfBbhDw9sFBbl8p7ttE4RPzcw==}
     peerDependencies:
       react: ^18.x || ^19.x
 
-  '@mantine/hooks@7.16.3':
-    resolution: {integrity: sha512-B94FBWk5Sc81tAjV+B3dGh/gKzfqzpzVC/KHyBRWOOyJRqeeRbI/FAaJo4zwppyQo1POSl5ArdyjtDRrRIj2SQ==}
+  '@mantine/hooks@8.0.2':
+    resolution: {integrity: sha512-0jpEdC0KIAZ54D5kd9rJudrEm6vkvnrL9yYHnkuNbxokXSzDdYA/wpHnKR5WW+u6fW4JF6A6A7gN1vXKeC9MSw==}
     peerDependencies:
       react: ^18.x || ^19.x
 
-  '@mantine/notifications@7.16.3':
-    resolution: {integrity: sha512-wtEME9kSYfXWYmAmQUZ8c+rwNmhdWRBaW1mlPdQsPkzMqkv4q6yy0IpgwcnuHStSG9EHaQBXazmVxMZJdEAWBQ==}
+  '@mantine/notifications@8.0.2':
+    resolution: {integrity: sha512-whSuoCCZxQF3VM40sumCte9tA79to8OCV/vv0z8PeVTj/eKlaTR+P9LKigO9ovhuNELrvvO3Rxcnno5aMBz0oA==}
     peerDependencies:
-      '@mantine/core': 7.16.3
-      '@mantine/hooks': 7.16.3
+      '@mantine/core': 8.0.2
+      '@mantine/hooks': 8.0.2
       react: ^18.x || ^19.x
       react-dom: ^18.x || ^19.x
 
-  '@mantine/store@7.16.3':
-    resolution: {integrity: sha512-6M2M5+0BrRtnVv+PUmr04tY1RjPqyapaHplo90uK1NMhP/1EIqrwTL9KoEtCNCJ5pog1AQtu0bj0QPbqUvxwLg==}
+  '@mantine/store@8.0.2':
+    resolution: {integrity: sha512-/LuizGWAXjVnLLZ55f0QYotiqb8GlHpIb4KRf4LqRkbsA6UAZEVb6beuk0vI2Azf6vfuh7sTHu1xVC5zI6C+Cw==}
     peerDependencies:
       react: ^18.x || ^19.x
 
@@ -3623,8 +3623,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-textarea-autosize@8.5.6:
-    resolution: {integrity: sha512-aT3ioKXMa8f6zHYGebhbdMD2L00tKeRX1zuVuDx9YQK/JLLRSaSxq3ugECEmUB9z2kvk6bFSIoRHLkkUv0RJiw==}
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5173,48 +5173,48 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@mantine/charts@7.17.3(@mantine/core@7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@7.16.3(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(recharts@2.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@mantine/charts@8.0.2(@mantine/core@8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@8.0.2(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(recharts@2.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
-      '@mantine/core': 7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@mantine/hooks': 7.16.3(react@19.0.0)
+      '@mantine/core': 8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mantine/hooks': 8.0.2(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       recharts: 2.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@mantine/core@7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@mantine/core@8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@mantine/hooks': 7.16.3(react@19.0.0)
+      '@mantine/hooks': 8.0.2(react@19.0.0)
       clsx: 2.1.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-number-format: 5.4.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-remove-scroll: 2.6.3(@types/react@19.0.8)(react@19.0.0)
-      react-textarea-autosize: 8.5.6(@types/react@19.0.8)(react@19.0.0)
+      react-textarea-autosize: 8.5.9(@types/react@19.0.8)(react@19.0.0)
       type-fest: 4.34.1
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mantine/form@7.17.3(react@19.0.0)':
+  '@mantine/form@8.0.2(react@19.0.0)':
     dependencies:
       fast-deep-equal: 3.1.3
       klona: 2.0.6
       react: 19.0.0
 
-  '@mantine/hooks@7.16.3(react@19.0.0)':
+  '@mantine/hooks@8.0.2(react@19.0.0)':
     dependencies:
       react: 19.0.0
 
-  '@mantine/notifications@7.16.3(@mantine/core@7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@7.16.3(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@mantine/notifications@8.0.2(@mantine/core@8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@mantine/hooks@8.0.2(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@mantine/core': 7.16.3(@mantine/hooks@7.16.3(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@mantine/hooks': 7.16.3(react@19.0.0)
-      '@mantine/store': 7.16.3(react@19.0.0)
+      '@mantine/core': 8.0.2(@mantine/hooks@8.0.2(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mantine/hooks': 8.0.2(react@19.0.0)
+      '@mantine/store': 8.0.2(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-transition-group: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@mantine/store@7.16.3(react@19.0.0)':
+  '@mantine/store@8.0.2(react@19.0.0)':
     dependencies:
       react: 19.0.0
 
@@ -5293,7 +5293,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/schedule@5.0.1(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1))':
+  '@nestjs/schedule@5.0.1(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)':
     dependencies:
       '@nestjs/common': 10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
@@ -5310,7 +5310,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0))':
+  '@nestjs/testing@10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)':
     dependencies:
       '@nestjs/common': 10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0(class-validator@0.14.1)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
@@ -8546,7 +8546,7 @@ snapshots:
     dependencies:
       react: 19.0.0
       react-style-singleton: 2.2.3(@types/react@19.0.8)(react@19.0.0)
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.8
 
@@ -8555,7 +8555,7 @@ snapshots:
       react: 19.0.0
       react-remove-scroll-bar: 2.3.8(@types/react@19.0.8)(react@19.0.0)
       react-style-singleton: 2.2.3(@types/react@19.0.8)(react@19.0.0)
-      tslib: 2.6.3
+      tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@19.0.8)(react@19.0.0)
       use-sidecar: 1.1.3(@types/react@19.0.8)(react@19.0.0)
     optionalDependencies:
@@ -8573,11 +8573,11 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       react: 19.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.8
 
-  react-textarea-autosize@8.5.6(@types/react@19.0.8)(react@19.0.0):
+  react-textarea-autosize@8.5.9(@types/react@19.0.8)(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.24.7
       react: 19.0.0
@@ -9395,7 +9395,7 @@ snapshots:
   use-callback-ref@1.3.3(@types/react@19.0.8)(react@19.0.0):
     dependencies:
       react: 19.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.8
 
@@ -9420,7 +9420,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 19.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.8
 

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"],
@@ -39,13 +39,15 @@
       "cache": false
     },
     "db:build": {
-      "cache": false
+      "cache": false,
+      "outputs": ["dist/**"]
     },
     "db:seed": {
       "cache": false
     },
     "services:build": {
-      "cache": false
+      "cache": false,
+      "outputs": ["dist/**"]
     },
     "services:watch": {
       "cache": false,


### PR DESCRIPTION
This commit upgrades all Mantine packages in the `apps/web` project to version 8.0.2. Key changes include:
- Updated `@mantine/charts`, `@mantine/core`, `@mantine/form`, `@mantine/hooks`, and `@mantine/notifications` to `8.0.2`.
- Kept `postcss-preset-mantine` at `1.17.0` (latest available).
- Resolved pnpm versioning and Turborepo build configuration issues to ensure the monorepo builds successfully. This involved:
    - Setting `packageManager: "pnpm@10.11.1"` in the root `package.json`.
    - Ensuring correct `build` script names in workspace packages (`@repo/db`, `@repo/services`).
    - Updating `turbo.json` to correctly track build outputs.
    - Adding `@repo/db` and `@repo/services` to `transpilePackages` in `apps/web/next.config.js`.
- Fixed TypeScript errors in `apps/web/app/dashboard/comments/page.tsx` and `apps/web/app/dashboard/profile/page.tsx` that arose due to the Mantine upgrade and type checking.

The application now builds successfully with the updated Mantine dependencies. Manual testing is recommended to verify UI and functionality.